### PR TITLE
초기 이미지 에러, 페이지 번호 추가, 메인 리스트 새로고침

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ lint/generated/
 lint/outputs/
 lint/tmp/
 # lint/reports/
+.idea/compiler.xml

--- a/app/src/main/java/com/uos/makebook/MainList/BookListActivity.java
+++ b/app/src/main/java/com/uos/makebook/MainList/BookListActivity.java
@@ -296,8 +296,6 @@ public class BookListActivity extends AppCompatActivity{
                 //성공
                 if (resultCode == Constant.MAKECOVER_RESULT_SUCCESS) {
                     Toast.makeText(getApplicationContext(), "표지 설정에 성공하셨습니다.", Toast.LENGTH_SHORT).show();
-                    refresh();
-                    return;
                 }
                 break;
 
@@ -308,7 +306,7 @@ public class BookListActivity extends AppCompatActivity{
             case Constant.EDIT_REQUEST:
                 break;
         }
-
+        refresh();
     }
 
         @Override
@@ -325,6 +323,7 @@ public class BookListActivity extends AppCompatActivity{
             case R.id.action_create2:
                 Toast.makeText(getApplicationContext(), "책 만들기를 시작합니다", Toast.LENGTH_LONG).show();
                 Intent nextIntent = new Intent(getApplicationContext(), MakeCoverActivity.class);
+                nextIntent.putExtra("create",1);
                 //startActivityForResult(nextIntent, Constant.MAKECOVER_REQUEST);
                 startActivity(nextIntent);
                 finish();

--- a/app/src/main/java/com/uos/makebook/Page/EditBookActivity.java
+++ b/app/src/main/java/com/uos/makebook/Page/EditBookActivity.java
@@ -36,13 +36,17 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 
+import static com.uos.makebook.Common.Constant.EDIT_REQUEST;
+
 public class EditBookActivity  extends PageActivity {
     private TextData editingText = null;
     private ImageData editingImage = null;
+    private int isCreated;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        isCreated = getIntent().getIntExtra("code",-1);
     }
 
     @Override
@@ -63,6 +67,7 @@ public class EditBookActivity  extends PageActivity {
     @Override
     public void complete(){
         super.complete();
+        startActivity(new Intent(getApplicationContext(), BookListActivity.class));
         finish();
         //종료하지 말고 그냥 디비에 수정된 페이지 반영하고 flipper는 계속 떠있도록 하고, 뒤로가기 하면 페이지모아보기 뜨도록 하면 좋을 것 같은데 어떤가요?(다현)
     }

--- a/app/src/main/java/com/uos/makebook/Page/PageListAdapter.java
+++ b/app/src/main/java/com/uos/makebook/Page/PageListAdapter.java
@@ -34,7 +34,7 @@ public class PageListAdapter extends RecyclerView.Adapter<PageListAdapter.ViewHo
     // Item을 하나 하나 보여주는(bind 되는) 함수
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
         Page item = pageItems.get(position);
-        holder.setItem(item);
+        holder.setItem(item, position);
     }
 
     @Override
@@ -76,6 +76,7 @@ public class PageListAdapter extends RecyclerView.Adapter<PageListAdapter.ViewHo
 
     public class ViewHolder extends RecyclerView.ViewHolder{
         ImageView pageView;
+        TextView pageNum;
         //private ImageView page_image; //페이지 이미지
 
         public ViewHolder(@NonNull View itemView) {
@@ -95,15 +96,17 @@ public class PageListAdapter extends RecyclerView.Adapter<PageListAdapter.ViewHo
             });
 
             pageView = itemView.findViewById(R.id.pageView);
+            pageNum = itemView.findViewById(R.id.textNum);
         }
 
         //pageItem 구성
-        public void setItem(Page item){
+        public void setItem(Page item, int position){
             Bitmap pageBitmap = Bitmap.createBitmap(screenSize.widthPixels, screenSize.heightPixels, Bitmap.Config.ARGB_8888);
             Canvas pageCanvas = new Canvas(pageBitmap);
             item.drawElements(pageCanvas);
 
             pageView.setImageBitmap(pageBitmap);
+            pageNum.setText(Integer.toString(position+1));
         }
     }
 }

--- a/app/src/main/res/layout/main_splash.xml
+++ b/app/src/main/res/layout/main_splash.xml
@@ -12,7 +12,6 @@
         android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.25"

--- a/app/src/main/res/layout/page_pagelist_item.xml
+++ b/app/src/main/res/layout/page_pagelist_item.xml
@@ -22,6 +22,14 @@
             android:layout_height="wrap_content"
             android:adjustViewBounds="true" />
 
+        <TextView
+            android:id="@+id/textNum"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="TextView" />
+
     </LinearLayout>
 
 </androidx.cardview.widget.CardView>


### PR DESCRIPTION
Splash 텍스트 치우쳐져있는거 수정했습니다.

페이지 모아보기 할때 번호 밑에 뜨게 추가했고
![image](https://user-images.githubusercontent.com/63439738/121361166-ff7f0780-c96f-11eb-8dea-04b8db122e4c.png)

책 만들기 이후 -> 메인리스트 새로고침 되게 했습니다.
(그냥 액티비티 새로 실행시켰습니다)